### PR TITLE
Add support for wildcard domains introduced in iOS 9.3

### DIFF
--- a/src/android/com/nordnetab/cordova/ul/UniversalLinksPlugin.java
+++ b/src/android/com/nordnetab/cordova/ul/UniversalLinksPlugin.java
@@ -207,7 +207,8 @@ public class UniversalLinksPlugin extends CordovaPlugin {
         ULHost host = null;
         final String launchHost = url.getHost().toLowerCase();
         for (ULHost supportedHost : supportedHosts) {
-            if (supportedHost.getName().equals(launchHost)) {
+            if (supportedHost.getName().equals(launchHost) ||
+                    supportedHost.getName().startsWith("*.") && launchHost.endsWith(supportedHost.getName().substring(1))) {
                 host = supportedHost;
                 break;
             }

--- a/src/ios/CULPlugin.m
+++ b/src/ios/CULPlugin.m
@@ -93,10 +93,9 @@
 - (CULHost *)findHostByURL:(NSURL *)launchURL {
     NSURLComponents *urlComponents = [NSURLComponents componentsWithURL:launchURL resolvingAgainstBaseURL:YES];
     CULHost *host = nil;
-    NSString *launchedHost = urlComponents.host.lowercaseString;
     for (CULHost *supportedHost in _supportedHosts) {
-        NSPredicate *pred = [NSPredicate predicateWithFormat:@"self LIKE %@", supportedHost.name];
-        if ([pred evaluateWithObject: launchedHost]) {
+        NSPredicate *pred = [NSPredicate predicateWithFormat:@"self LIKE[c] %@", supportedHost.name];
+        if ([pred evaluateWithObject: urlComponents.host]) {
             host = supportedHost;
             break;
         }

--- a/src/ios/CULPlugin.m
+++ b/src/ios/CULPlugin.m
@@ -95,7 +95,8 @@
     CULHost *host = nil;
     NSString *launchedHost = urlComponents.host.lowercaseString;
     for (CULHost *supportedHost in _supportedHosts) {
-        if ([supportedHost.name isEqualToString:launchedHost]) {
+        NSPredicate *pred = [NSPredicate predicateWithFormat:@"self LIKE %@", supportedHost.name];
+        if ([pred evaluateWithObject: launchedHost]) {
             host = supportedHost;
             break;
         }


### PR DESCRIPTION
Starting with version 9.3, iOS now supports wildcard domains in universal link declarations (see current version of [official documentation](https://developer.apple.com/library/ios/documentation/General/Conceptual/AppSearch/UniversalLinks.html)). This works out of the box with this plugin, i.e. the proper entitlements are created and the os interaction works as expected. The only problem is that no JS event is triggered, since the plugin code cannot identify the proper event name.

The attached changes update the `findHostByURL` method to match host names using wildcards. 

Additionally the changes introduced for #44 are updated to also use the predicate match - this was done to avoid creating a second local var, while predicate matches already support case insensitive matching.

Please note, that Android also supports wildcard subdomains in `intent-filter` declarations. To make this work `UniversalLinksPlugin.findHostByUrl` would need to be updated accordingly.
