### PR TITLE
Handle links opened from iOS smart app banner

### DIFF
--- a/src/ios/CULPlugin.m
+++ b/src/ios/CULPlugin.m
@@ -37,6 +37,18 @@
 //    [self handleUserActivity:activity];
 //}
 
+- (void)handleOpenURL:(NSNotification*)notification
+{
+    NSURL* url = [notification object];
+
+    if ([url isKindOfClass:[NSURL class]]) {
+        CULHost *host = [self findHostByURL:url];
+        if (host != nil) {
+            [self storeEventWithHost:host originalURL:url];
+        }
+    }
+}
+
 - (BOOL)handleUserActivity:(NSUserActivity *)userActivity {
     [self localInit];
     


### PR DESCRIPTION
This adds a handler for URLs opened from a smart app banner in Safari, as described in the section, "Providing Navigational Context to Your App." It is slightly different from the way this plugin already works, since the URL opened notification has a different code path when it is opened from the smart app banner, than when you click a link to an associated domain and it automatically opens the app.

https://developer.apple.com/library/content/documentation/AppleApplications/Reference/SafariWebContent/PromotingAppswithAppBanners/PromotingAppswithAppBanners.html

Cordova provides the facility for forwarding the call from `application:openURL:sourceApplication:annotation:` to the plugin's `handleOpenURL:` method.