### PR TITLE
Distinctive applinks host for different schemas

### DIFF
--- a/hooks/lib/ios/projectEntitlements.js
+++ b/hooks/lib/ios/projectEntitlements.js
@@ -114,7 +114,8 @@ function generateAssociatedDomainsContent(pluginPreferences) {
   // generate list of host links
   pluginPreferences.hosts.forEach(function(host) {
     link = domainsListEntryForHost(host);
-    domainsList.push(link);
+    if(domainsList.indexOf(link) == -1)
+		  domainsList.push(link);
   });
 
   return domainsList;


### PR DESCRIPTION
In case of multiple schemas (e.g. http\https) with the same host, generate distinctive host for iOS entitlements file generated