### PR TITLE
modified plugin to process root path without a forward slash on android

### DIFF
--- a/hooks/lib/android/manifestWriter.js
+++ b/hooks/lib/android/manifestWriter.js
@@ -306,7 +306,7 @@ function injectPathComponentIntoIntentFilter(intentFilter, pathName) {
     pathName = pathName.replace(/\*/g, '.*');
   }
 
-  if (pathName.indexOf('/') != 0) {
+  if (pathName !== "" && pathName.indexOf('/') != 0) {
     pathName = '/' + pathName;
   }
 


### PR DESCRIPTION
#125 Resolves the ability to handle a link on android which has an empty string as its path in config.xml.