### PR TITLE
Do not crash when app is opened via custom uri

### DIFF
--- a/src/android/com/nordnetab/cordova/ul/UniversalLinksPlugin.java
+++ b/src/android/com/nordnetab/cordova/ul/UniversalLinksPlugin.java
@@ -205,10 +205,13 @@ public class UniversalLinksPlugin extends CordovaPlugin {
      */
     private ULHost findHostByUrl(Uri url) {
         ULHost host = null;
-        final String launchHost = url.getHost().toLowerCase();
+        final String launchHost = url.getHost();
+        if (launchHost == null)
+            return null;
+        final String launchHostLc = launchHost.toLowerCase();
         for (ULHost supportedHost : supportedHosts) {
-            if (supportedHost.getName().equals(launchHost) ||
-                    supportedHost.getName().startsWith("*.") && launchHost.endsWith(supportedHost.getName().substring(1))) {
+            if (supportedHost.getName().equals(launchHostLc) ||
+                    supportedHost.getName().startsWith("*.") && launchHostLc.endsWith(supportedHost.getName().substring(1))) {
                 host = supportedHost;
                 break;
             }


### PR DESCRIPTION
The intent handler is also triggered for custom URIs like
com.example.app:/oauth2redirect; In this case getHost() returns null and
the plugin crashes.
