### PR TITLE
Use existing entitlements

### DIFF
--- a/hooks/lib/ios/projectEntitlements.js
+++ b/hooks/lib/ios/projectEntitlements.js
@@ -9,13 +9,10 @@ Script only generates content. File it self is included in the xcode project in 
 var path = require('path');
 var fs = require('fs');
 var plist = require('plist');
-var mkpath = require('mkpath');
 var ConfigXmlHelper = require('../configXmlHelper.js');
 var ASSOCIATED_DOMAINS = 'com.apple.developer.associated-domains';
 var context;
-var projectRoot;
 var projectName;
-var entitlementsFilePath;
 
 module.exports = {
   generateAssociatedDomainsEntitlements: generateEntitlements
@@ -33,6 +30,7 @@ function generateEntitlements(cordovaContext, pluginPreferences) {
   context = cordovaContext;
 
   var currentEntitlements = getEntitlementsFileContent();
+  console.log(currentEntitlements);
   var newEntitlements = injectPreferences(currentEntitlements, pluginPreferences);
 
   saveContentToEntitlementsFile(newEntitlements);
@@ -51,11 +49,11 @@ function saveContentToEntitlementsFile(content) {
   var plistContent = plist.build(content);
   var filePath = pathToEntitlementsFile();
 
-  // ensure that file exists
-  mkpath.sync(path.dirname(filePath));
-
-  // save it's content
-  fs.writeFileSync(filePath, plistContent, 'utf8');
+  ['Debug', 'Release'].forEach(config => {
+    var entitlementsPath = path.join(filePath, 'Entitlements-' + config + '.plist');
+    // save it's content
+    fs.writeFileSync(entitlementsPath, plistContent, 'utf8');
+  });
 }
 
 /**
@@ -64,7 +62,7 @@ function saveContentToEntitlementsFile(content) {
  * @return {String} entitlements file content
  */
 function getEntitlementsFileContent() {
-  var pathToFile = pathToEntitlementsFile();
+  var pathToFile = path.join(pathToEntitlementsFile(), 'Entitlements-Debug.plist');
   var content;
 
   try {
@@ -141,11 +139,7 @@ function domainsListEntryForHost(host) {
  * @return {String} absolute path to entitlements file
  */
 function pathToEntitlementsFile() {
-  if (entitlementsFilePath === undefined) {
-    entitlementsFilePath = path.join(getProjectRoot(), 'platforms', 'ios', getProjectName(), 'Resources', getProjectName() + '.entitlements');
-  }
-
-  return entitlementsFilePath;
+  return path.join(getProjectRoot(), 'platforms/ios/', getProjectName());
 }
 
 /**

--- a/hooks/lib/ios/xcodePreferences.js
+++ b/hooks/lib/ios/xcodePreferences.js
@@ -8,7 +8,6 @@ Which is:
 
 var path = require('path');
 var compare = require('node-version-compare');
-var ConfigXmlHelper = require('../configXmlHelper.js');
 var IOS_DEPLOYMENT_TARGET = '8.0';
 var COMMENT_KEY = /_comment$/;
 var context;
@@ -32,11 +31,9 @@ function enableAssociativeDomainsCapability(cordovaContext) {
   // adjust preferences
   activateAssociativeDomains(projectFile.xcode);
 
-  // add entitlements file to pbxfilereference
-  addPbxReference(projectFile.xcode);
-
   // save changes
-  projectFile.write();
+  projectFile.write()
+  console.log("Enabled domains")
 }
 
 // endregion
@@ -52,14 +49,13 @@ function enableAssociativeDomainsCapability(cordovaContext) {
  */
 function activateAssociativeDomains(xcodeProject) {
   var configurations = nonComments(xcodeProject.pbxXCBuildConfigurationSection());
-  var entitlementsFilePath = pathToEntitlementsFile();
+  //var entitlementsFilePath = pathToEntitlementsFile();
   var config;
   var buildSettings;
   var deploymentTargetIsUpdated;
 
   for (config in configurations) {
     buildSettings = configurations[config].buildSettings;
-    buildSettings['CODE_SIGN_ENTITLEMENTS'] = '"' + entitlementsFilePath + '"';
 
     // if deployment target is less then the required one - increase it
     if (buildSettings['IPHONEOS_DEPLOYMENT_TARGET']) {
@@ -76,54 +72,9 @@ function activateAssociativeDomains(xcodeProject) {
   if (deploymentTargetIsUpdated) {
     console.log('IOS project now has deployment target set as: ' + IOS_DEPLOYMENT_TARGET);
   }
-
-  console.log('IOS project Code Sign Entitlements now set to: ' + entitlementsFilePath);
 }
 
 // endregion
-
-// region PBXReference methods
-
-/**
- * Add .entitlemets file into the project.
- *
- * @param {Object} xcodeProject - xcode project preferences; all changes are made in that instance
- */
-function addPbxReference(xcodeProject) {
-  var fileReferenceSection = nonComments(xcodeProject.pbxFileReferenceSection());
-  var entitlementsFileName = path.basename(pathToEntitlementsFile());
-
-  if (isPbxReferenceAlreadySet(fileReferenceSection, entitlementsFileName)) {
-    console.log('Entitlements file is in reference section.');
-    return;
-  }
-
-  console.log('Entitlements file is not in references section, adding it');
-  xcodeProject.addResourceFile(entitlementsFileName);
-}
-
-/**
- * Check if .entitlemets file reference already set.
- *
- * @param {Object} fileReferenceSection - PBXFileReference section
- * @param {String} entitlementsRelativeFilePath - relative path to entitlements file
- * @return true - if reference is set; otherwise - false
- */
-function isPbxReferenceAlreadySet(fileReferenceSection, entitlementsRelativeFilePath) {
-  var isAlreadyInReferencesSection = false;
-  var uuid;
-  var fileRefEntry;
-
-  for (uuid in fileReferenceSection) {
-    fileRefEntry = fileReferenceSection[uuid];
-    if (fileRefEntry.path && fileRefEntry.path.indexOf(entitlementsRelativeFilePath) > -1) {
-      isAlreadyInReferencesSection = true;
-      break;
-    }
-  }
-
-  return isAlreadyInReferencesSection;
-}
 
 // region Xcode project file helpers
 
@@ -135,15 +86,15 @@ function isPbxReferenceAlreadySet(fileReferenceSection, entitlementsRelativeFile
 function loadProjectFile() {
   var platform_ios;
   var projectFile;
-
+  
   try {
     // try pre-5.0 cordova structure
     platform_ios = context.requireCordovaModule('cordova-lib/src/plugman/platforms')['ios'];
     projectFile = platform_ios.parseProjectFile(iosPlatformPath());
   } catch (e) {
-    // let's try cordova 5.0 structure
-    platform_ios = context.requireCordovaModule('cordova-lib/src/plugman/platforms/ios');
-    projectFile = platform_ios.parseProjectFile(iosPlatformPath());
+      // let's try cordova 5.0 structure
+      platform_ios = context.requireCordovaModule('cordova-lib/src/plugman/platforms/ios');
+      projectFile = platform_ios.parseProjectFile(iosPlatformPath());
   }
 
   return projectFile;
@@ -178,14 +129,6 @@ function iosPlatformPath() {
 
 function projectRoot() {
   return context.opts.projectRoot;
-}
-
-function pathToEntitlementsFile() {
-  var configXmlHelper = new ConfigXmlHelper(context),
-    projectName = configXmlHelper.getProjectName(),
-    fileName = projectName + '.entitlements';
-
-  return path.join(projectName, 'Resources', fileName);
 }
 
 // endregion


### PR DESCRIPTION
This plugins creates a new entitlements file for associating the domain, which breaks apps that add other options to the existing entitlement files.

This PR simply uses existing entitlement files in the platform directory.