### PR TITLE
Fixed hook script error for iOS build where v1.indexof() is not found.

### DIFF
--- a/hooks/lib/ios/xcodePreferences.js
+++ b/hooks/lib/ios/xcodePreferences.js
@@ -63,7 +63,8 @@ function activateAssociativeDomains(xcodeProject) {
 
     // if deployment target is less then the required one - increase it
     if (buildSettings['IPHONEOS_DEPLOYMENT_TARGET']) {
-      if (compare(buildSettings['IPHONEOS_DEPLOYMENT_TARGET'], IOS_DEPLOYMENT_TARGET) == -1) {
+        var buildDeploymentTarget = buildSettings['IPHONEOS_DEPLOYMENT_TARGET'].toString();
+        if (compare(buildDeploymentTarget, IOS_DEPLOYMENT_TARGET) == -1) {
         buildSettings['IPHONEOS_DEPLOYMENT_TARGET'] = IOS_DEPLOYMENT_TARGET;
         deploymentTargetIsUpdated = true;
       }


### PR DESCRIPTION
I ran into the same issue as:
https://github.com/nordnet/cordova-universal-links-plugin/issues/71

On the cordova Branch plugin, they fixed it like this:
https://github.com/BranchMetrics/cordova-ionic-phonegap-branch-deep-linking/pull/141/commits/cec48d8b429d8f3edcef369e8f842743c42a1062

With those lines changed, the issue is fixed.